### PR TITLE
CMS-319473 - Adds timeout to ip_to_geo

### DIFF
--- a/src/prefixes/GeoPrefix.js
+++ b/src/prefixes/GeoPrefix.js
@@ -24,7 +24,8 @@ class GeoPrefix {
 				ip
 			},
 			url : this._graphUrl,
-			token : context.token
+			token : context.token,
+			timeout : context.timeout
 		});
 		
 		const returnData = result.geo.ip_to_geo;

--- a/src/prefixes/GeoPrefix.js
+++ b/src/prefixes/GeoPrefix.js
@@ -7,7 +7,12 @@ class GeoPrefix {
 		this._graphUrl = graphUrl;
 		this._graphServer = graphServer;
 	}
-	async ip_to_geo({ ip, fields, context }) {
+	async ip_to_geo({
+		ip,
+		fields,
+		timeout = 5000,
+		context
+	}) {
 		context = context || this._graphServer.context;
 		
 		const result = await query({
@@ -25,7 +30,7 @@ class GeoPrefix {
 			},
 			url : this._graphUrl,
 			token : context.token,
-			timeout : context.timeout
+			timeout
 		});
 		
 		const returnData = result.geo.ip_to_geo;
@@ -34,7 +39,11 @@ class GeoPrefix {
 		
 		return returnData;
 	}
-	async _generic(method, { fields, context }) {
+	async _generic(method, {
+		fields,
+		timeout = 5000,
+		context
+	}) {
 		context = context || this._graphServer.context;
 		
 		const result = await query({
@@ -48,7 +57,8 @@ class GeoPrefix {
 				}
 			`,
 			url : this._graphUrl,
-			token : context.token
+			token : context.token,
+			timeout
 		});
 		
 		const returnData = result.geo[method];


### PR DESCRIPTION
This adds passes through `context.timeout` to the query for `ip_to_geo()`. Timeout is undefined if not passed to maintain backwards compatability.